### PR TITLE
fix(Assertions|Helpers): multiple fixes

### DIFF
--- a/src/util/insertAfterPath.js
+++ b/src/util/insertAfterPath.js
@@ -1,14 +1,12 @@
 import * as t from 'babel-types'
 
-const insertAfterPath = (path, expression) => {
-  if (t.isExportDeclaration(path.parent)) {
-    const parent = path.findParent(parentPath => parentPath.isExportDeclaration())
+const findTarget = path => {
+  if (t.isExportDeclaration(path.parent)) return path.findParent(parentPath => parentPath.isExportDeclaration())
+  if (t.isExpression(path)) return path.findParent(parentPath => parentPath.isDeclaration())
 
-    parent.insertAfter(expression)
-    return
-  }
-
-  path.insertAfter(expression)
+  return path
 }
+
+const insertAfterPath = (path, expression) => findTarget(path).insertAfter(expression)
 
 export default insertAfterPath

--- a/src/util/isReactFunction.js
+++ b/src/util/isReactFunction.js
@@ -4,7 +4,10 @@ import getBody from './getBody'
 import hasReturnStatement from './hasReturnStatement'
 
 const isFunction = path => {
-  return t.isArrowFunctionExpression(path) || t.isFunctionDeclaration(path) || t.isFunctionExpression(path)
+  if (t.isFunctionDeclaration(path)) return true
+  if (!t.isArrowFunctionExpression(path) && !t.isFunctionExpression(path)) return false
+
+  return t.isVariableDeclarator(path.parent)
 }
 
 const isReactFunction = path => isFunction(path) && hasReturnStatement(getBody(path))

--- a/test/fixtures/skiped-arrow/actual.js
+++ b/test/fixtures/skiped-arrow/actual.js
@@ -1,0 +1,11 @@
+import React, { Component, PropTypes } from 'react';
+
+export default class Example extends Component {
+  render() {
+    return null;
+  }
+
+  renderItems = () => {
+    return null;
+  }
+}

--- a/test/fixtures/skiped-arrow/expected.js
+++ b/test/fixtures/skiped-arrow/expected.js
@@ -1,0 +1,17 @@
+import React, { Component, PropTypes } from 'react';
+
+export default class Example extends Component {
+  constructor(...args) {
+    var _temp;
+
+    return _temp = super(...args), this.renderItems = () => {
+      return null;
+    }, _temp;
+  }
+
+  render() {
+    return null;
+  }
+
+}
+Example.handledProps = [];

--- a/test/fixtures/stateless-arrow/expected.js
+++ b/test/fixtures/stateless-arrow/expected.js
@@ -1,10 +1,9 @@
 import React, { PropTypes } from 'react';
 
-const Example = (_temp = () => {
-  var _temp;
-
+const Example = () => {
   return null;
-}, Example.handledProps = ['active', 'children', 'className'], _temp);
+};
+Example.handledProps = ['active', 'children', 'className'];
 Example.defaultProps = {
   active: true
 };

--- a/test/fixtures/stateless-assignment/expected.js
+++ b/test/fixtures/stateless-assignment/expected.js
@@ -1,10 +1,9 @@
 import React, { PropTypes } from 'react';
 
-const Example = (_temp = function () {
-  var _temp;
-
+const Example = function () {
   return null;
-}, Example.handledProps = ['active', 'children', 'className'], _temp);
+};
+Example.handledProps = ['active', 'children', 'className'];
 Example.defaultProps = {
   active: true
 };


### PR DESCRIPTION
Next iteration of testing on live-code shown:
* wrong result of `isReactFunction` assertions, it failed on such code;
* wrong path definition on `insertAfterPath` helper.

This PR fixes these issues.