### PR TITLE
fix(Append): fix `findTarget` for function's expressions

### DIFF
--- a/src/util/appendProps.js
+++ b/src/util/appendProps.js
@@ -11,8 +11,14 @@ const createPropertyExpression = (identifier, props) => {
 }
 
 const findTarget = path => {
-  if (t.isExportDeclaration(path.parent)) return path.findParent(parentPath => parentPath.isExportDeclaration())
-  if (t.isExpression(path)) return path.findParent(parentPath => parentPath.isDeclaration())
+  if (t.isArrowFunctionExpression(path) || t.isFunctionExpression(path)) {
+    const declarationPath = path.findParent(parentPath => t.isVariableDeclaration(parentPath))
+
+    return findTarget(declarationPath)
+  }
+
+  if (t.isExportDeclaration(path.parent)) return path.findParent(parentPath => t.isExportDeclaration(parentPath))
+  if (t.isExpression(path)) return path.findParent(parentPath => t.isDeclaration(parentPath))
 
   return path
 }

--- a/test/fixtures/multiple-arrow/actual.js
+++ b/test/fixtures/multiple-arrow/actual.js
@@ -1,0 +1,8 @@
+import React, { PropTypes } from 'react';
+
+export const First = () => <div />;
+First.propTypes = {
+  children: PropTypes.node
+};
+
+export const Second = () => null;

--- a/test/fixtures/multiple-arrow/expected.js
+++ b/test/fixtures/multiple-arrow/expected.js
@@ -1,0 +1,9 @@
+import React, { PropTypes } from 'react';
+
+export const First = () => React.createElement('div', null);
+First.handledProps = ['children'];
+First.propTypes = {
+  children: PropTypes.node
+};
+
+export const Second = () => null;


### PR DESCRIPTION
This PR fixes `findTarget` behavior for function's expressions.