### PR TITLE
style(test): cleanup tests, use parser opts

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,8 +4,9 @@
       "targets": {
         "node": "4"
       }
-    }],
-    "react",
-    "stage-0"
+    }]
+  ],
+  "plugins": [
+    "babel-plugin-transform-class-properties"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,15 +8,14 @@
     "src"
   ],
   "dependencies": {
-    "babel-preset-env": "^1.6.1",
     "babel-types": "^6.26.0",
     "lodash": "^4.17.4"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.0",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "eslint": "^4.6.1",
     "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-prettier": "^2.3.1",
@@ -28,14 +27,12 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "babel src -d lib",
-    "lint": "eslint .",
-    "lint:fix": "npm run lint -- --fix",
+    "lint": "prettier --list-different \"src/**/*.js\" \"test/test.js\" && eslint \"src/**/*.js\" \"test/test.js\"",
+    "lint:fix": "prettier --write \"src/**/*.js\" \"test/test.js\" && eslint --fix \"src/**/*.js\" \"test/test.js\"",
     "prerelease": "npm run clean && npm run build",
     "release:major": "npm run prerelease && ta-script npm/release.sh major",
     "release:minor": "npm run prerelease && ta-script npm/release.sh minor",
     "release:patch": "npm run prerelease && ta-script npm/release.sh patch",
-    "lint": "prettier --list-different \"src/**/*.js\" \"test/test.js\" && eslint \"src/**/*.js\" \"test/test.js\"",
-    "lint:fix": "prettier --write \"src/**/*.js\" \"test/test.js\" && eslint --fix \"src/**/*.js\" \"test/test.js\"",
     "test": "mocha --require babel-register \"test/*.js\"",
     "test:watch": "npm run test -- --watch --watch-extensions js"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,11 @@ import { entryVisitor, importVisitor, propVisitor } from './visitors'
 import { appendProps, Store } from './util'
 
 const plugin = () => ({
+  manipulateOptions: (opts, parserOptions) => {
+    parserOptions.plugins.push('classProperties')
+    parserOptions.plugins.push('jsx')
+    parserOptions.plugins.push('objectRestSpread')
+  },
   pre() {
     this.store = new Store()
   },

--- a/test/fixtures/.babelrc
+++ b/test/fixtures/.babelrc
@@ -1,9 +1,5 @@
 {
   "plugins": [
     ["../../src"]
-  ],
-  "presets": [
-    "react",
-    "stage-0"
   ]
 }

--- a/test/fixtures/hoc-unnamed/actual.js
+++ b/test/fixtures/hoc-unnamed/actual.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export const HOC = Child => class extends Component {
   static propTypes = {

--- a/test/fixtures/hoc-unnamed/expected.js
+++ b/test/fixtures/hoc-unnamed/expected.js
@@ -1,15 +1,14 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
-export const HOC = Child => {
-  var _class, _temp;
-
-  return _temp = _class = class extends Component {
-
-    render() {
-      return React.createElement(Child, null);
-    }
-  }, _class.propTypes = {
+export const HOC = Child => class extends Component {
+  static propTypes = {
     children: PropTypes.node
-  }, _class.handledProps = ['children'], _temp;
+  };
+
+  render() {
+    return <Child />;
+  }
+  static handledProps = ['children'];
 };
 HOC.handledProps = [];

--- a/test/fixtures/hoc/actual.js
+++ b/test/fixtures/hoc/actual.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function Foo() {
   return function Bar(Component) {

--- a/test/fixtures/hoc/expected.js
+++ b/test/fixtures/hoc/expected.js
@@ -1,17 +1,18 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function Foo() {
   return function Bar(Component) {
-    var _class, _temp;
-
-    return _temp = _class = class Baz extends React.Component {
+    return class Baz extends React.Component {
+      static propTypes = {
+        children: PropTypes.node
+      };
 
       render() {
-        return React.createElement(Component, null);
+        return <Component />;
       }
-    }, _class.propTypes = {
-      children: PropTypes.node
-    }, _class.handledProps = ['children'], _temp;
+      static handledProps = ['children'];
+    };
   };
 }
 Foo.handledProps = [];

--- a/test/fixtures/multiple-arrow/actual.js
+++ b/test/fixtures/multiple-arrow/actual.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export const First = () => <div />;
 First.propTypes = {

--- a/test/fixtures/multiple-arrow/expected.js
+++ b/test/fixtures/multiple-arrow/expected.js
@@ -1,6 +1,7 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
-export const First = () => React.createElement('div', null);
+export const First = () => <div />;
 First.handledProps = ['children'];
 First.propTypes = {
   children: PropTypes.node

--- a/test/fixtures/multiple/actual.js
+++ b/test/fixtures/multiple/actual.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export function First() {
   return <div />;

--- a/test/fixtures/multiple/expected.js
+++ b/test/fixtures/multiple/expected.js
@@ -1,12 +1,13 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export function First() {
-  return React.createElement('div', null);
+  return <div />;
 }
 
 First.handledProps = ['children'];
 export function Second() {
-  return React.createElement('div', null);
+  return <div />;
 }
 
 Second.handledProps = ['children'];

--- a/test/fixtures/skiped-arrow/actual.js
+++ b/test/fixtures/skiped-arrow/actual.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class Example extends Component {
   render() {

--- a/test/fixtures/skiped-arrow/expected.js
+++ b/test/fixtures/skiped-arrow/expected.js
@@ -1,17 +1,13 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class Example extends Component {
-  constructor(...args) {
-    var _temp;
-
-    return _temp = super(...args), this.renderItems = () => {
-      return null;
-    }, _temp;
-  }
-
   render() {
     return null;
   }
 
+  renderItems = () => {
+    return null;
+  };
+  static handledProps = [];
 }
-Example.handledProps = [];

--- a/test/fixtures/skiped/actual.js
+++ b/test/fixtures/skiped/actual.js
@@ -1,3 +1,6 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
 function Example() {
   return null;
 }

--- a/test/fixtures/skiped/expected.js
+++ b/test/fixtures/skiped/expected.js
@@ -1,3 +1,6 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
 function Example() {
   return null;
 }

--- a/test/fixtures/spread/actual.js
+++ b/test/fixtures/spread/actual.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const someProps = {
   active: PropTypes.boolean

--- a/test/fixtures/spread/expected.js
+++ b/test/fixtures/spread/expected.js
@@ -1,19 +1,19 @@
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const someProps = {
   active: PropTypes.boolean
 };
 
 function Example() {
-  return React.createElement('div', null);
+  return <div />;
 }
 
 Example.handledProps = ['children', 'className'];
-Example.propTypes = _extends({}, someProps, {
+Example.propTypes = {
+  ...someProps,
   children: PropTypes.node,
   className: PropTypes.string
-});
+};
 
 export default Example;

--- a/test/fixtures/statefull-predefined/actual.js
+++ b/test/fixtures/statefull-predefined/actual.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class Example extends Component {
   render() {

--- a/test/fixtures/statefull-predefined/expected.js
+++ b/test/fixtures/statefull-predefined/expected.js
@@ -1,11 +1,12 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class Example extends Component {
   render() {
     return null;
   }
+  static handledProps = ['children', 'className'];
 }
-Example.handledProps = ['children', 'className'];
 
 Example.propTypes = {
   children: PropTypes.node

--- a/test/fixtures/statefull-static/actual.js
+++ b/test/fixtures/statefull-static/actual.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class Example extends Component {
   static handledProps = ['className'];

--- a/test/fixtures/statefull-static/expected.js
+++ b/test/fixtures/statefull-static/expected.js
@@ -1,15 +1,18 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class Example extends Component {
+
+  static defaultProps = {
+    active: true
+  };
+
+  static propTypes = {
+    children: PropTypes.node
+  };
 
   render() {
     return null;
   }
+  static handledProps = ['active', 'children', 'className'];
 }
-Example.defaultProps = {
-  active: true
-};
-Example.propTypes = {
-  children: PropTypes.node
-};
-Example.handledProps = ['active', 'children', 'className'];

--- a/test/fixtures/statefull/actual.js
+++ b/test/fixtures/statefull/actual.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class Example extends Component {
   render() {

--- a/test/fixtures/statefull/expected.js
+++ b/test/fixtures/statefull/expected.js
@@ -1,11 +1,12 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class Example extends Component {
   render() {
     return null;
   }
+  static handledProps = ['children', 'className'];
 }
-Example.handledProps = ['children', 'className'];
 Example.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string

--- a/test/fixtures/stateless-arrow/actual.js
+++ b/test/fixtures/stateless-arrow/actual.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const Example = () => <div />;
 Example.defaultProps = {

--- a/test/fixtures/stateless-arrow/expected.js
+++ b/test/fixtures/stateless-arrow/expected.js
@@ -1,6 +1,7 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
-const Example = () => React.createElement('div', null);
+const Example = () => <div />;
 Example.handledProps = ['active', 'children', 'className'];
 Example.defaultProps = {
   active: true

--- a/test/fixtures/stateless-assignment/actual.js
+++ b/test/fixtures/stateless-assignment/actual.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const Example = function () {
   return <div />;

--- a/test/fixtures/stateless-assignment/expected.js
+++ b/test/fixtures/stateless-assignment/expected.js
@@ -1,7 +1,8 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const Example = function () {
-  return React.createElement('div', null);
+  return <div />;
 };
 Example.handledProps = ['active', 'children', 'className'];
 Example.defaultProps = {

--- a/test/fixtures/stateless-predefined/actual.js
+++ b/test/fixtures/stateless-predefined/actual.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 function Example() {
   return <div />;

--- a/test/fixtures/stateless-predefined/expected.js
+++ b/test/fixtures/stateless-predefined/expected.js
@@ -1,7 +1,8 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 function Example() {
-  return React.createElement('div', null);
+  return <div />;
 }
 Example.handledProps = ['children', 'className'];
 

--- a/test/fixtures/stateless/actual.js
+++ b/test/fixtures/stateless/actual.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 function Example() {
   return <div />;

--- a/test/fixtures/stateless/expected.js
+++ b/test/fixtures/stateless/expected.js
@@ -1,7 +1,8 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 function Example() {
-  return React.createElement('div', null);
+  return <div />;
 }
 Example.handledProps = ['active', 'children', 'className'];
 Example.defaultProps = {


### PR DESCRIPTION
This PR:
- removes cruft presets from `package.json`
- cleanups tests from useless transforms