### PR TITLE
Added support for flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 *.log
 lib
+package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# babel-plugin-transform-react-handled-props
+# babel-plugin-transform-react-flow-handled-props
 
 Generates handledProps from defaultProps and propTypes during the build :sparkles:
 
-[![Build Status](https://travis-ci.org/layershifter/babel-plugin-transform-react-handled-props.svg?branch=master)](https://travis-ci.org/layershifter/babel-plugin-transform-react-handled-props)
-[![Gemnasium](https://img.shields.io/gemnasium/layershifter/babel-plugin-transform-react-handled-props.svg?style=flat)](https://gemnasium.com/layershifter/babel-plugin-transform-react-handled-props)
-[![npm](https://img.shields.io/npm/v/babel-plugin-transform-react-handled-props.svg?style=flat)](https://www.npmjs.com/package/babel-plugin-transform-react-handled-props)
+[![Build Status](https://travis-ci.org/simonguo/babel-plugin-transform-react-flow-handled-props.svg?branch=master)](https://travis-ci.org/layershifter/babel-plugin-transform-react-flow-handled-props)
+[![Gemnasium](https://img.shields.io/gemnasium/simonguo/babel-plugin-transform-react-flow-handled-props.svg?style=flat)](https://gemnasium.com/simonguo/babel-plugin-transform-react-flow-handled-props)
+[![npm](https://img.shields.io/npm/v/babel-plugin-transform-react-flow-handled-props.svg?style=flat)](https://www.npmjs.com/package/babel-plugin-transform-react-flow-handled-props)
 
 ## Installation
 
 ```sh
-$ npm install --save-dev babel-plugin-transform-react-handled-props
+$ npm install --save-dev babel-plugin-transform-react-flow-handled-props
 ```
 
 ## Story
@@ -95,6 +95,8 @@ class Foo extends React.Component {
 
 ## Example transform
 
+### PropTypes
+
 **In**
 
 ```js
@@ -123,6 +125,60 @@ Baz.propTypes = {
 }
 ```
 
+### Flow Props
+
+
+**In**
+
+```js
+// @flow
+
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+type Props = {
+  name?: string,
+  _text?: string,
+  'aria-describedby'?: string,
+  children?: React.Node
+}
+
+class Baz extends React.Component<Props> {
+
+  render() {
+    return <div {...this.props} />;
+  }
+}
+
+export default Baz;
+```
+
+**Out**
+
+```js
+// @flow
+
+import * as React from 'react';
+
+type Props = {
+  name?: string;
+  _text?: string;
+  'aria-describedby'?: string;
+  children?: React.Node;
+};
+
+class Baz extends React.Component<Props> {
+
+  render() {
+    return <div {...this.props} />;
+  }
+  static handledProps = ['_text', 'aria-describedby', 'children', 'name'];
+}
+
+export default Baz;
+```
+
+
 ## Usage
 
 ### Via `.babelrc` (Recommended)
@@ -131,21 +187,21 @@ Baz.propTypes = {
 
 ```json
 {
-  "plugins": ["transform-react-handled-props"]
+  "plugins": ["transform-react-flow-handled-props"]
 }
 ```
 
 ### Via CLI
 
 ```sh
-$ babel --plugins transform-react-handled-props script.js
+$ babel --plugins transform-react-flow-handled-props script.js
 ```
 
 ### Via Node API
 
 ```javascript
 require("babel-core").transform("code", {
-  plugins: ["transform-react-handled-props"]
+  plugins: ["transform-react-flow-handled-props"]
 });
 ```
 
@@ -157,7 +213,7 @@ This options allows to ignore some props, this will allow to not add them to `ha
 
 ```json
 {
-  "plugins": ["transform-react-handled-props", { "ignoredProps": ["children"] }]
+  "plugins": ["transform-react-flow-handled-props", { "ignoredProps": ["children"] }]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "babel-plugin-transform-react-handled-props",
-  "version": "0.3.0",
+  "name": "babel-plugin-transform-react-flow-handled-props",
+  "version": "0.1.4",
   "description": "Generates handledProps from defaultProps and propTypes during the build",
   "main": "lib/index.js",
   "files": [
@@ -49,9 +49,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://github.com/layershifter/babel-plugin-transform-react-handled-props.git"
+    "url": "git+ssh://github.com/simonguo/babel-plugin-transform-react-flow-handled-props.git"
   },
   "author": "Alexander Fedyashov <a@fedyashov.com>",
-  "homepage": "https://github.com/layershifter/babel-plugin-transform-react-handled-props",
+  "homepage": "https://github.com/simonguo/babel-plugin-transform-react-flow-handled-props",
   "license": "MIT"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const plugin = () => ({
     parserOptions.plugins.push('classProperties')
     parserOptions.plugins.push('jsx')
     parserOptions.plugins.push('objectRestSpread')
+    parserOptions.plugins.push('flow')
   },
   pre() {
     this.store = new Store()

--- a/src/visitors/propVisitor.js
+++ b/src/visitors/propVisitor.js
@@ -19,7 +19,26 @@ const getObjectKeys = ({ properties }) => {
   return _.map(objectProperties, ({ key: { name } = {} }) => name)
 }
 
+const getFlowTypeKeys = path => {
+  const globals = Object.keys(_.get(path, 'scope.globals')) || []
+  return _.filter(globals, key => key !== 'Node')
+}
+
+const getTypeAliasIdentifier = path => {
+  const entries = _.get(path, 'state.entries')
+  if (!entries) {
+    return
+  }
+  return _.get(Object.keys(entries), '0')
+}
+
 const propVisitor = {
+  TypeAlias(path, state) {
+    const identifier = getTypeAliasIdentifier(path)
+    if (identifier) {
+      state.addProps(identifier, getFlowTypeKeys(path))
+    }
+  },
   AssignmentExpression(path, state) {
     const identifier = getExpressionIdentifier(path)
     const right = _.get(path, 'node.right')

--- a/src/visitors/propVisitor.js
+++ b/src/visitors/propVisitor.js
@@ -20,16 +20,24 @@ const getObjectKeys = ({ properties }) => {
 }
 
 const getFlowTypeKeys = path => {
-  const globals = Object.keys(_.get(path, 'scope.globals')) || []
-  return _.filter(globals, key => key !== 'Node')
+  const properties = _.get(path, 'node.right.properties') || []
+  return properties.map(item => {
+    let type = _.get(item, 'key.type')
+    if (type === 'StringLiteral') {
+      return _.get(item, 'key.value')
+    } else if (type === 'Identifier') {
+      return _.get(item, 'key.name')
+    }
+    return
+  })
 }
 
 const getTypeAliasIdentifier = path => {
-  const entries = _.get(path, 'state.entries')
-  if (!entries) {
+  const body = _.get(path, 'parent.body') || []
+  if (!body) {
     return
   }
-  return _.get(Object.keys(entries), '0')
+  return _.get(body.find(item => item.type === 'ClassDeclaration'), 'id.name')
 }
 
 const propVisitor = {

--- a/test/fixtures/flow/actual.js
+++ b/test/fixtures/flow/actual.js
@@ -1,0 +1,19 @@
+// @flow
+
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+type Props = {
+  name?:string,
+  qq?:string,
+  children?: React.Node
+}
+
+class Baz extends React.Component<Props> {
+
+  render() {
+    return <div {...this.props} />;
+  }
+}
+
+export default Baz;

--- a/test/fixtures/flow/actual.js
+++ b/test/fixtures/flow/actual.js
@@ -4,8 +4,9 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 
 type Props = {
-  name?:string,
-  qq?:string,
+  name?: string,
+  _text?: string,
+  'aria-describedby'?: string,
   children?: React.Node
 }
 

--- a/test/fixtures/flow/expected.js
+++ b/test/fixtures/flow/expected.js
@@ -1,0 +1,20 @@
+// @flow
+
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+type Props = {
+  name?: string;
+  qq?: string;
+  children?: React.Node;
+};
+
+class Baz extends React.Component<Props> {
+
+  render() {
+    return <div {...this.props} />;
+  }
+  static handledProps = ['children', 'name', 'qq'];
+}
+
+export default Baz;

--- a/test/fixtures/flow/expected.js
+++ b/test/fixtures/flow/expected.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 type Props = {
   name?: string;
-  qq?: string;
+  _text?: string;
   children?: React.Node;
 };
 
@@ -14,7 +14,7 @@ class Baz extends React.Component<Props> {
   render() {
     return <div {...this.props} />;
   }
-  static handledProps = ['children', 'name', 'qq'];
+  static handledProps = ['_text', 'aria-describedby', 'children', 'name'];
 }
 
 export default Baz;

--- a/test/fixtures/flow/expected.js
+++ b/test/fixtures/flow/expected.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 type Props = {
   name?: string;
   _text?: string;
+  'aria-describedby'?: string;
   children?: React.Node;
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -45,4 +45,5 @@ describe('fixtures', () => {
   fixtureAssert('stateless-arrow')
   fixtureAssert('stateless-assignment')
   fixtureAssert('stateless-predefined')
+  fixtureAssert('flow')
 })


### PR DESCRIPTION
in
```js
// @flow

import * as React from 'react';
import PropTypes from 'prop-types';

type Props = {
  name?: string,
  _text?: string,
  'aria-describedby'?: string,
  children?: React.Node
}

class Baz extends React.Component<Props> {

  render() {
    return <div {...this.props} />;
  }
}

export default Baz;
```

out:

```js
// @flow

import * as React from 'react';
import PropTypes from 'prop-types';

type Props = {
  name?: string;
  _text?: string;
  'aria-describedby'?: string;
  children?: React.Node;
};

class Baz extends React.Component<Props> {

  render() {
    return <div {...this.props} />;
  }
  static handledProps = ['_text', 'aria-describedby', 'children', 'name'];
}

export default Baz;
```
