### PR TITLE
fix(plugin): fix in processing string props

### DIFF
--- a/src/util/getObjectKeys.js
+++ b/src/util/getObjectKeys.js
@@ -1,0 +1,14 @@
+import * as t from 'babel-types'
+import _ from 'lodash'
+
+import { isObjectProperty } from './types'
+
+const getObjectKey = ({ key }) => (t.isStringLiteral(key) ? key.value : key.name)
+
+const getObjectKeys = ({ properties }) => {
+  const objectProperties = _.filter(properties, isObjectProperty)
+
+  return _.map(objectProperties, getObjectKey)
+}
+
+export default getObjectKeys

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,8 +1,9 @@
 export { default as appendProps } from './appendProps'
 
 export { default as getClassDeclaration } from './getClassDeclaration'
-export { default as getExpressionIdentifier } from './getExpressionIdentifier'
 export { default as getEntryIdentifier } from './getEntryIdentifier'
+export { default as getExpressionIdentifier } from './getExpressionIdentifier'
+export { default as getObjectKeys } from './getObjectKeys'
 
 export { default as isReactComponent } from './isReactComponent'
 export { default as isReactImport } from './isReactImport'

--- a/src/visitors/propVisitor.js
+++ b/src/visitors/propVisitor.js
@@ -3,8 +3,8 @@ import {
   getClassDeclaration,
   getEntryIdentifier,
   getExpressionIdentifier,
+  getObjectKeys,
   isArrayValue,
-  isObjectProperty,
   isObjectValue,
   isStaticProperty,
   isValidExpression,
@@ -12,12 +12,6 @@ import {
 } from '../util'
 
 const getArrayItems = ({ elements }) => _.map(elements, ({ value }) => value)
-
-const getObjectKeys = ({ properties }) => {
-  const objectProperties = _.filter(properties, isObjectProperty)
-
-  return _.map(objectProperties, ({ key: { name } = {} }) => name)
-}
 
 const propVisitor = {
   AssignmentExpression(path, state) {

--- a/test/fixtures/attr-string/actual.js
+++ b/test/fixtures/attr-string/actual.js
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+function Example() {
+  return <div />;
+}
+
+Example.propTypes = {
+  'aria-label': PropTypes.string,
+  children: PropTypes.node
+};
+
+export default Example;

--- a/test/fixtures/attr-string/expected.js
+++ b/test/fixtures/attr-string/expected.js
@@ -1,0 +1,14 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+function Example() {
+  return <div />;
+}
+
+Example.handledProps = ['aria-label', 'children'];
+Example.propTypes = {
+  'aria-label': PropTypes.string,
+  children: PropTypes.node
+};
+
+export default Example;

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,8 @@ const fixtureAssert = (fixtureDir, options = []) =>
   })
 
 describe('fixtures', () => {
+  fixtureAssert('attr-string')
+
   fixtureAssert('hoc')
   fixtureAssert('hoc-unnamed')
 


### PR DESCRIPTION
### Expected behavior

Correctly transform:

```jsx
Example.propTypes = {
  'aria-label': PropTypes.string,
};
```

### Actual behavior

Thrown exception.

----

This PR fixes work with string props, see added fixtures for details.
